### PR TITLE
Add support of type blocks and do some minor refactoring

### DIFF
--- a/cmd/gofield/files_test.go
+++ b/cmd/gofield/files_test.go
@@ -161,7 +161,7 @@ type TestStruct struct {
 	if err != nil {
 		t.Errorf("Apply fixes failed: %v", err)
 	}
-	if !strings.Contains(output, "Applying fixes to files:") {
+	if !strings.Contains(output, "Applied fixes to 1 files") {
 		t.Errorf("Unexpected output for apply fixes: %s", output)
 	}
 	// Проверяем, что структура была оптимизирована

--- a/cmd/gofield/main_test.go
+++ b/cmd/gofield/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"go/format"
 	"os"
 	"testing"
 )
@@ -38,12 +39,15 @@ func TestStructAlignment(t *testing.T) {
 	calculateStructures(structures, false)
 	debugPrintStructures(structures)
 
-	err = renderTextStructures(structures)
+	renderTextStructures(structures)
+
+	// Replace content
+	resultFile, err := Replacer(enterFIle, structures)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Replace content
-	resultFile, err := Replacer(enterFIle, structures)
+
+	resultFile, err = format.Source(resultFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gofield/render.go
+++ b/cmd/gofield/render.go
@@ -33,7 +33,7 @@ func renderStructure(elem *Structure) string {
 	}
 
 	if elem.Root != nil {
-		data += fmt.Sprintf("type ")
+		// Don't add "type " here, as current structure may be inside a "type" block
 		data += fmt.Sprintf("%s struct{", elem.Name)
 	} else {
 		data += fmt.Sprintf("struct {")
@@ -89,14 +89,12 @@ func renderStructure(elem *Structure) string {
 	return data
 }
 
-func renderTextStructures(structures []*Structure) error {
+func renderTextStructures(structures []*Structure) {
 	for _, structure := range structures {
-		txtCode := renderStructure(structure)
-		code, err := formatGoCode(txtCode)
-		if err != nil {
-			return err
-		}
-		structure.MetaData.Data = []byte(code)
+		// Don't format code here - "renderStructure" generates a replacement for a part of target Go file,
+		// not a valid piece of Go code per-se.
+		//
+		// Code will be formatted afterwards.
+		structure.MetaData.Data = []byte(renderStructure(structure))
 	}
-	return nil
 }

--- a/cmd/gofield/utils.go
+++ b/cmd/gofield/utils.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"go/ast"
-	"go/format"
 	"sort"
 	"strings"
 	"unicode"
@@ -30,15 +29,6 @@ var stdTypes = map[string]bool{
 	"float64":    true,
 	"complex64":  true,
 	"complex128": true,
-}
-
-// formatGoCode formats the given Go code string
-func formatGoCode(code string) (string, error) {
-	formatted, err := format.Source([]byte(code))
-	if err != nil {
-		return "", err
-	}
-	return string(formatted), nil
 }
 
 // getTypeString returns a string representation of an AST expression

--- a/cmd/gofield/utils_test.go
+++ b/cmd/gofield/utils_test.go
@@ -6,46 +6,6 @@ import (
 	"testing"
 )
 
-// TestFormatGoCode tests the formatGoCode function.
-// It checks if the function correctly formats valid Go code
-// and handles malformed code appropriately.
-func TestFormatGoCode(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "simple function",
-			input:    "func main() { fmt.Println(\"Hello, World!\") }",
-			expected: "func main() { fmt.Println(\"Hello, World!\") }",
-		},
-		{
-			name:     "malformed code",
-			input:    "func main() { fmt.Println(\"Hello, World!\") ",
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := formatGoCode(tt.input)
-			if tt.expected == "" {
-				if err == nil {
-					t.Errorf("Expected error for malformed code, got nil")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("Unexpected error: %v", err)
-				}
-				if result != tt.expected {
-					t.Errorf("Expected %q, got %q", tt.expected, result)
-				}
-			}
-		})
-	}
-}
-
 // TestGetTypeString tests the getTypeString function.
 // It verifies that the function correctly converts various AST expressions
 // to their string representations.


### PR DESCRIPTION
Hi.

Currently `go-field-alignment` doesn't support type blocks:

```go
type (
    A1 struct {
    }

    A2 struct {
    }
)
```

This pull request adds this feature and refactors existing code a bit:
1. `printUsage()` has been moved to `main` (as it's purely CLI-related);
2. Go code formatting gets applied only after replacements get applied - this allows us to remove a couple of crutches from various places.

Thanks.