### PR TITLE
Add support of same-typed fields

### DIFF
--- a/cmd/gofield/creator.go
+++ b/cmd/gofield/creator.go
@@ -1,22 +1,40 @@
 package main
 
-import "go/ast"
+import (
+	"go/ast"
+)
 
 // ============= Creator Item
 
-// createItemInfoName extracts the name from the given AST node.
-// It handles TypeSpec and Field nodes, returning an empty string for unsupported types.
-func createItemInfoName(data interface{}) string {
-	switch elem := data.(type) {
-	case *ast.TypeSpec:
-		return elem.Name.Name
-	case *ast.Field:
-		if len(elem.Names) == 0 {
-			return ""
-		}
-		return elem.Names[0].Name
+// createTypeName extracts the name from a type spec.
+func createTypeName(spec *ast.TypeSpec) string {
+	return spec.Name.Name
+}
+
+// createFieldNames extracts field names from a field spec.
+//
+// Returns multiple names when the specified field spec is actually a definition of multiple same-typed fields.
+// Returns a slice with a single empty string in case of embedded types.
+//
+//		type A1 struct{}
+//
+//		type A2 struct {
+//		  A1                // <-------- []string{""}
+//		  F1 int            // <-------- []string{"F1"}
+//		  F2 string         // <-------- []string{"F2"}
+//	      F3, F4, F5 string // <-------- []string{"F3", "F4", "F5"}
+//		}
+func createFieldNames(field *ast.Field) []string {
+	c := len(field.Names)
+	if c == 0 {
+		// This is a case of an embedded type - return a slice with an empty string
+		return []string{""}
 	}
-	return ""
+	names := make([]string, c)
+	for i := 0; i < c; i++ {
+		names[i] = field.Names[i].Name
+	}
+	return names
 }
 
 // createItemInfoPath generates a path string for an item.
@@ -28,58 +46,78 @@ func createItemInfoPath(name, parentName string) string {
 	return name
 }
 
-// createItemInfo creates an Structure structure from the given AST node.
-// It handles TypeSpec and Field nodes, processing their contents and creating nested structures as needed.
+// createTypeItemInfo creates a Structure from the given AST type node.
+// It processes its contents and creates nested structures as needed.
 // The function also updates the provided mapper with the created Structure.
-func createItemInfo(data interface{}, parentData *Structure, mapper map[string]*Structure) *Structure {
-	switch Elem := data.(type) {
-	case *ast.TypeSpec:
-		newItem := &Structure{
-			Name:        createItemInfoName(Elem),
-			Root:        Elem,
-			StructType:  Elem.Type,
-			IsStructure: true,
-			StringType:  getTypeString(Elem.Type),
-		}
-		if newItem.Name == "" {
-			newItem.Name = "!" + newItem.StringType
-		}
-		newItem.Path = createItemInfoPath(newItem.Name, "")
-		mapper[newItem.Path] = newItem
-		if elem, ok := Elem.Type.(*ast.StructType); ok {
-			for _, field := range elem.Fields.List {
-				newField := createItemInfo(field, newItem, mapper)
-				if newField != nil {
-					newItem.NestedFields = append(newItem.NestedFields, newField)
-				}
-			}
-		}
-		return newItem
-	case *ast.Field:
-		newItem := &Structure{
-			Name:       createItemInfoName(Elem),
-			RootField:  Elem,
-			StructType: Elem.Type,
-			StringType: getTypeString(Elem.Type),
-		}
-		if newItem.Name == "" {
-			newItem.Name = "!" + newItem.StringType
-		}
-		newItem.Path = createItemInfoPath(newItem.Name, parentData.Path)
-		mapper[newItem.Path] = newItem
-		if ident, ok := Elem.Type.(*ast.Ident); ok {
-			newItem.IsStructure = ident.Obj != nil
-		}
-		if elem, ok := Elem.Type.(*ast.StructType); ok {
-			newItem.IsStructure = true
-			for _, field := range elem.Fields.List {
-				newField := createItemInfo(field, newItem, mapper)
-				if newField != nil {
-					newItem.NestedFields = append(newItem.NestedFields, newField)
-				}
-			}
-		}
-		return newItem
+func createTypeItemInfo(typeSpec *ast.TypeSpec, parent *Structure, mapper map[string]*Structure) *Structure {
+	typeInfo := &Structure{
+		Name:        createTypeName(typeSpec),
+		Root:        typeSpec,
+		StructType:  typeSpec.Type,
+		IsStructure: true,
+		StringType:  getTypeString(typeSpec.Type),
 	}
-	return nil
+	if typeInfo.Name == "" {
+		typeInfo.Name = "!" + typeInfo.StringType
+	}
+
+	typeInfo.Path = createItemInfoPath(typeInfo.Name, "")
+	mapper[typeInfo.Path] = typeInfo
+
+	if structType, ok := typeSpec.Type.(*ast.StructType); ok {
+		for _, field := range structType.Fields.List {
+			newFields := createFieldItemsInfo(field, typeInfo, mapper)
+			if len(newFields) > 0 {
+				typeInfo.NestedFields = append(typeInfo.NestedFields, newFields...)
+			}
+		}
+	}
+
+	return typeInfo
+}
+
+// createFieldItemsInfo creates a list of Structure-s from the given AST field node.
+// The number of returned Structure-s is defined by how field node looks like.
+// It processes its contents and creates nested structures as needed.
+// The function also updates the provided mapper with the created Structures.
+func createFieldItemsInfo(field *ast.Field, parent *Structure, mapper map[string]*Structure) []*Structure {
+	fieldNames := createFieldNames(field)
+	fieldInfos := make([]*Structure, len(fieldNames))
+	for i, name := range fieldNames {
+		fieldInfos[i] = createSingleFieldItemInfo(name, field, parent, mapper)
+	}
+	return fieldInfos
+}
+
+// createSingleFieldItemInfo creates a single Structure from the given AST field node.
+// It processes its contents and creates nested structures as needed.
+// The function also updates the provided mapper with the created Structure.
+func createSingleFieldItemInfo(name string, field *ast.Field, parent *Structure, mapper map[string]*Structure) *Structure {
+	fieldInfo := &Structure{
+		Name:       name,
+		RootField:  field,
+		StructType: field.Type,
+		StringType: getTypeString(field.Type),
+	}
+	if fieldInfo.Name == "" {
+		fieldInfo.Name = "!" + fieldInfo.StringType
+	}
+
+	fieldInfo.Path = createItemInfoPath(fieldInfo.Name, parent.Path)
+	mapper[fieldInfo.Path] = fieldInfo
+
+	switch typed := field.Type.(type) {
+	case *ast.Ident:
+		fieldInfo.IsStructure = typed.Obj != nil
+	case *ast.StructType:
+		fieldInfo.IsStructure = true
+		for _, nestedField := range typed.Fields.List {
+			nestedFieldItems := createFieldItemsInfo(nestedField, fieldInfo, mapper)
+			if len(nestedFieldItems) > 0 {
+				fieldInfo.NestedFields = append(fieldInfo.NestedFields, nestedFieldItems...)
+			}
+		}
+	}
+
+	return fieldInfo
 }

--- a/cmd/gofield/types.go
+++ b/cmd/gofield/types.go
@@ -82,7 +82,7 @@ func parseData(path string, bytes []byte) ([]*Structure, map[string]*Structure, 
 			StartPos: startPos,
 			EndPos:   endPos,
 		}
-		item := createItemInfo(typeSpec, nil, mapperItems)
+		item := createTypeItemInfo(typeSpec, nil, mapperItems)
 		item.MetaData = &metaData
 		if item != nil {
 			structures = append(structures, item)
@@ -91,6 +91,7 @@ func parseData(path string, bytes []byte) ([]*Structure, map[string]*Structure, 
 	})
 	return structures, mapperItems, err
 }
+
 func createMapperItem(structure *Structure, mapperItems map[string]*Structure) map[string]*Structure {
 	mapperItems[structure.Path] = structure
 	if structure.IsStructure {
@@ -100,6 +101,7 @@ func createMapperItem(structure *Structure, mapperItems map[string]*Structure) m
 	}
 	return mapperItems
 }
+
 func createMapper(structures []*Structure) map[string]*Structure {
 	mapper := map[string]*Structure{}
 	for _, structure := range structures {

--- a/tests/enter/file.go
+++ b/tests/enter/file.go
@@ -9,12 +9,24 @@ type Problem1 struct{}
 type Problem2 struct {
 }
 type Problem3 struct {
-	hello string
-	typer bool
+	hello, hello2 string
+	typer         bool
 	time.Time
 	time.Duration
 	time.Location
 }
+
+type (
+	S1 struct {
+		F1 bool
+		F2 string
+	}
+
+	S2 struct {
+		F1, F2 bool
+		F3     string
+	}
+)
 
 type STR string
 type STRs []string

--- a/tests/out/file.go
+++ b/tests/out/file.go
@@ -8,12 +8,26 @@ import (
 type Problem1 struct{}
 type Problem2 struct{}
 type Problem3 struct {
-	hello string
+	hello  string
+	hello2 string
 	time.Time
 	time.Duration
 	time.Location
 	typer bool
 }
+
+type (
+	S1 struct {
+		F2 string
+		F1 bool
+	}
+
+	S2 struct {
+		F3 string
+		F1 bool
+		F2 bool
+	}
+)
 
 type STR string
 type STRs []string


### PR DESCRIPTION
Hi.

This PR adds support of same-typed fields in structs:

```go
type A1 struct {
    F1, F2, F3 string
}
```

Currently, `go-field-alignment` outputs only the first field from such definitions:

```go
type A1 struct {
    F1 string
}
```

Additionally, added this case and a case from previous PR to `main_test`.

Thanks.