### PR TITLE
Add support of `interface{}` and `struct{}` types in fields

### DIFF
--- a/cmd/gofield/utils.go
+++ b/cmd/gofield/utils.go
@@ -58,9 +58,9 @@ func getTypeString(expr ast.Expr) string {
 	case *ast.ChanType:
 		return getChanTypeString(t)
 	case *ast.StructType:
-		return "struct{...}"
+		return "struct{}"
 	case *ast.InterfaceType:
-		return "interface{...}"
+		return "interface{}"
 	case *ast.Ellipsis:
 		return "..." + getTypeString(t.Elt)
 	case *ast.ParenExpr:

--- a/tests/enter/file.go
+++ b/tests/enter/file.go
@@ -36,6 +36,8 @@ type MyTest struct {
 	a        bool // 1 byte
 	nameX    string
 	Problem1 struct {
+		I interface{}
+		S struct{}
 	}
 	b   bool // 1 byte
 	App struct {

--- a/tests/out/file.go
+++ b/tests/out/file.go
@@ -42,9 +42,12 @@ type MyTest struct {
 		IsProduction              bool          `yaml:"is_production" env:"IS_PRODUCTION" yaml-default:"true"`
 	} `yaml:"app"`
 	nameX    string
-	a        bool // 1 byte
-	b        bool // 1 byte
-	Problem1 struct{}
+	Problem1 struct {
+		I interface{}
+		S struct{}
+	}
+	a bool // 1 byte
+	b bool // 1 byte
 } /* some text
 dsdsd
 dsds


### PR DESCRIPTION
Hi.

This PR adds supports of `interface{}` and `struct{}` types in struct fields.

Tests have been modified accordingly.

Thanks.