### PR TITLE
Add support of generic types (type params in structs, generic types in struct fields)

### DIFF
--- a/cmd/gofield/utils.go
+++ b/cmd/gofield/utils.go
@@ -69,6 +69,9 @@ func getTypeString(expr ast.Expr) string {
 		return getTypeString(t.Type)
 	case *ast.FuncLit:
 		return getFuncTypeString(t.Type)
+	// Generics
+	case *ast.IndexExpr:
+		return fmt.Sprintf("%s[%s]", getTypeString(t.X), getTypeString(t.Index))
 	default:
 		return fmt.Sprintf("%T", expr)
 	}

--- a/cmd/gofield/utils.go
+++ b/cmd/gofield/utils.go
@@ -69,10 +69,20 @@ func getTypeString(expr ast.Expr) string {
 		return getTypeString(t.Type)
 	case *ast.FuncLit:
 		return getFuncTypeString(t.Type)
-	// Generics
 	case *ast.IndexExpr:
+		// Single type argument
 		return fmt.Sprintf("%s[%s]", getTypeString(t.X), getTypeString(t.Index))
+	case *ast.IndexListExpr:
+		// Multiple type arguments
+		idxTypes := make([]string, len(t.Indices))
+		for i, idx := range t.Indices {
+			idxTypes[i] = getTypeString(idx)
+		}
+		return fmt.Sprintf("%s[%s]", getTypeString(t.X), strings.Join(idxTypes, ", "))
 	default:
+		// TODO: maybe, it's better to fail here?
+		//
+		// It'll be easier to add support of what we've missed.
 		return fmt.Sprintf("%T", expr)
 	}
 }

--- a/tests/enter/file.go
+++ b/tests/enter/file.go
@@ -16,6 +16,10 @@ type Problem3 struct {
 	time.Location
 }
 
+type StructWithGenerics[T any] struct {
+	F T
+}
+
 type (
 	S1 struct {
 		F1 bool
@@ -25,6 +29,7 @@ type (
 	S2 struct {
 		F1, F2 bool
 		F3     string
+		F4     StructWithGenerics[int]
 	}
 )
 

--- a/tests/enter/file.go
+++ b/tests/enter/file.go
@@ -20,6 +20,12 @@ type StructWithGenerics[T any] struct {
 	F T
 }
 
+type StructWithMoreGenerics[T1, T2 any, T3 comparable] struct {
+	F1 T1
+	F2 T2
+	F3 T3
+}
+
 type (
 	S1 struct {
 		F1 bool
@@ -30,6 +36,7 @@ type (
 		F1, F2 bool
 		F3     string
 		F4     StructWithGenerics[int]
+		F5     StructWithMoreGenerics[int, float64, string]
 	}
 )
 

--- a/tests/out/file.go
+++ b/tests/out/file.go
@@ -20,6 +20,12 @@ type StructWithGenerics[T any] struct {
 	F T
 }
 
+type StructWithMoreGenerics[T1, T2 any, T3 comparable] struct {
+	F1 T1
+	F2 T2
+	F3 T3
+}
+
 type (
 	S1 struct {
 		F2 string
@@ -29,6 +35,7 @@ type (
 	S2 struct {
 		F3 string
 		F4 StructWithGenerics[int]
+		F5 StructWithMoreGenerics[int, float64, string]
 		F1 bool
 		F2 bool
 	}

--- a/tests/out/file.go
+++ b/tests/out/file.go
@@ -16,6 +16,10 @@ type Problem3 struct {
 	typer bool
 }
 
+type StructWithGenerics[T any] struct {
+	F T
+}
+
 type (
 	S1 struct {
 		F2 string
@@ -24,6 +28,7 @@ type (
 
 	S2 struct {
 		F3 string
+		F4 StructWithGenerics[int]
 		F1 bool
 		F2 bool
 	}


### PR DESCRIPTION
Hi.

This PR adds support of generic types in structs and struct fields.

```go
type StructWithGenerics[T any] struct {
    F T
}

type StructWithMoreGenerics[T1, T2 any, T3 comparable] struct {
    F1 T1
    F2 T2
    F3 T3
}

type StructWithGenericField struct {
    F1 StructWithGenerics[int]
    F2 StructWithMoreGenerics[int, float64, string]
}
```

Tests have been modified accordingly.

Please note that support of such types is not full - I have not added calculation of size of such generic values, but at least it doesn't ruin the existing code now.

Thanks.